### PR TITLE
3-generic-metrics: Allow for any metric to be retrieved instead of hardcoding cpu-utilization

### DIFF
--- a/src/lib/datadog-importer/index.ts
+++ b/src/lib/datadog-importer/index.ts
@@ -34,12 +34,22 @@ export const DatadogImporter = (
     const instanceIdTag: string = globalConfig['instance-id-tag'];
     const locationTag: string = globalConfig['location-tag'];
     const instanceTypeTag: string = globalConfig['instance-type-tag'];
-    const metric: string = globalConfig['metric'];
-    const outputMetricName: string = globalConfig['output-metric-name'];
+    const metrics: string = globalConfig['metrics'];
+    const outputMetricNames: string = globalConfig['output-metric-names'];
 
     config;
 
-    if (!(await determineIfMetricExists(apiInstance, metric))) {
+    const metricList = metrics.split(',');
+    const outputMetricNameList = outputMetricNames.split(',');
+
+    if (metricList.length !== outputMetricNameList.length) {
+      console.error(
+        'Validation Error: metrics and output-metrics-names length must be equal.'
+      );
+      return inputs;
+    }
+
+    if (!(await determineIfMetricsExist(apiInstance, metricList))) {
       return inputs;
     }
 
@@ -49,79 +59,81 @@ export const DatadogImporter = (
       const startUnixTime: number = Math.round(start.getTime() / 1000);
       console.log(start.toISOString());
 
-      const params: v1.MetricsApiQueryMetricsRequest = {
-        from: startUnixTime,
-        to: startUnixTime + input.duration,
-        query: `avg:${metric}{${instanceIdTag}:${input['instance-id']}}by{${instanceTypeTag},${locationTag}}`,
-      };
+      for (let i = 0; i < metricList.length; i++) {
+        const metric = metricList[i];
+        const outputMetricName = outputMetricNameList[i];
 
-      const data = (await apiInstance
-        .queryMetrics(params)
-        .then((data: v1.MetricsQueryResponse) => {
-          return data;
-        })
-        .catch((error: any) => {
-          console.error(error);
-        })) as v1.MetricsQueryResponse;
-
-      // TODO average over time series
-      // TODO handle multiple series
-      const series = data.series || [];
-      if (series.length === 0) {
-        console.log('Series not found');
-        continue;
-      }
-
-      const parseTag = (tag: string, tagSet: string[]) => {
-        for (const pair of tagSet) {
-          const [key, value] = pair.split(':', 2);
-          if (key === tag) {
-            return value;
-          }
-        }
-        return '';
-      };
-
-      const tags = series[0].tagSet || [];
-
-      const pointlist = series[0].pointlist || [];
-      if (pointlist.length === 0) {
-        console.log('Points not found');
-        continue;
-      }
-
-      for (let i = 0; i < pointlist.length; i++) {
-        const point = pointlist[i];
-        let nextTimeStamp;
-        if (i === pointlist.length - 1) {
-          nextTimeStamp =
-            new Date(input.timestamp).getTime() + input.duration * 1000;
-        } else {
-          nextTimeStamp = pointlist[i + 1][0];
-        }
-        const timestamp = point[0];
-        const value = point[1];
-
-        const output: OutputObject = {
-          ...input,
-          timestamp: new Date(timestamp).toISOString(),
-          duration: (nextTimeStamp - timestamp) / 1000,
-          location: parseTag(locationTag, tags),
-          'cloud/instance-type': parseTag(instanceTypeTag, tags),
+        const params: v1.MetricsApiQueryMetricsRequest = {
+          from: startUnixTime,
+          to: startUnixTime + input.duration,
+          query: `avg:${metric}{${instanceIdTag}:${input['instance-id']}}by{${instanceTypeTag},${locationTag}}`,
         };
 
-        if (outputMetricName in output) {
-          console.error(
-            `output-metric-name "${outputMetricName}" is set to a reserved key. It cannot be any of the following: ${Object.keys(
-              output
-            )}`
-          );
-          break;
-        } else {
-          output[outputMetricName] = value;
+        const data = (await apiInstance
+          .queryMetrics(params)
+          .then((data: v1.MetricsQueryResponse) => {
+            return data;
+          })
+          .catch((error: any) => {
+            console.error(error);
+          })) as v1.MetricsQueryResponse;
+
+        // TODO average over time series
+        // TODO handle multiple series
+        const series = data.series || [];
+        if (series.length === 0) {
+          console.log('Series not found');
+          continue;
         }
 
-        outputs = [...outputs, output];
+        const tags = series[0].tagSet || [];
+
+        const pointlist = series[0].pointlist || [];
+        if (pointlist.length === 0) {
+          console.log('Points not found');
+          continue;
+        }
+
+        for (let j = 0; j < pointlist.length; j++) {
+          const point = pointlist[j];
+          let nextTimeStamp;
+          if (j === pointlist.length - 1) {
+            nextTimeStamp =
+              new Date(input.timestamp).getTime() + input.duration * 1000;
+          } else {
+            nextTimeStamp = pointlist[j + 1][0];
+          }
+          const timestamp = point[0];
+          const value = point[1];
+
+          let output: DatadogImporterParams;
+          if (i === 0) {
+            output = {
+              ...input,
+              timestamp: new Date(timestamp).toISOString(),
+              duration: (nextTimeStamp - timestamp) / 1000,
+              location: parseTag(locationTag, tags),
+              'cloud/instance-type': parseTag(instanceTypeTag, tags),
+            };
+          } else {
+            output = outputs[j];
+          }
+
+          if (outputMetricName in output) {
+            console.error(
+              `output-metric-name "${outputMetricName}" is set to a reserved key. It cannot be any of the following: ${Object.keys(
+                output
+              )}`
+            );
+            break;
+          } else {
+            output[outputMetricName] = value;
+          }
+
+          if (i === 0) {
+            outputs = [...outputs, output];
+          }
+        }
       }
     }
 
@@ -129,48 +141,53 @@ export const DatadogImporter = (
   };
 
   /**
-   * Calls Datadog to determine if metric exists
+   * Calls Datadog to determine if metrics exist
    * @param apiInstance Datadog metrics api instance
-   * @param metric metric name in question
-   * @returns true if metric exists, false if not or could not be determined
+   * @param metrics metric names in question
+   * @returns true if all metrics exist, false if not or could not be determined
    */
-  async function determineIfMetricExists(
+  async function determineIfMetricsExist(
     apiInstance: v1.MetricsApi,
-    metric: string
+    metrics: string[]
   ): Promise<boolean> {
-    const params: v1.MetricsApiGetMetricMetadataRequest = {
-      metricName: metric,
-    };
+    for (const metric of metrics) {
+      const params: v1.MetricsApiGetMetricMetadataRequest = {
+        metricName: metric,
+      };
 
-    try {
-      await apiInstance.getMetricMetadata(params);
-      return true; // If the request is successful, the metric exists
-    } catch (error) {
-      if (error instanceof ApiException) {
-        if (error.code === 404) {
-          console.error(`Metric ${metric} does not exist`);
+      try {
+        // If the request is successful, the metric exists
+        await apiInstance.getMetricMetadata(params);
+      } catch (error) {
+        if (error instanceof ApiException) {
+          if (error.code === 404) {
+            console.error(`Metric ${metric} does not exist`);
+          } else {
+            console.error(
+              `Error determining if metric ${metric} exists: ${error.body.errors.join(
+                ', '
+              )}`
+            );
+          }
         } else {
           console.error(
-            `Error determining if metric ${metric} exists: ${error.body.errors.join(
-              ', '
-            )}`
+            `Unexpected error determining if metric ${metric} exists: ${error}`
           );
         }
-      } else {
-        console.error(
-          `Unexpected error determining if metric ${metric} exists: ${error}`
-        );
+        return false;
       }
-      return false;
     }
+    return true;
   }
 
-  interface OutputObject {
-    [key: string]: any;
-    timestamp: string;
-    duration: number;
-    location: string;
-    'cloud/instance-type': string;
+  function parseTag(tag: string, tagSet: string[]) {
+    for (const pair of tagSet) {
+      const [key, value] = pair.split(':', 2);
+      if (key === tag) {
+        return value;
+      }
+    }
+    return '';
   }
 
   return {

--- a/src/lib/datadog-importer/index.ts
+++ b/src/lib/datadog-importer/index.ts
@@ -44,7 +44,14 @@ export const DatadogImporter = (
 
     if (metricList.length !== outputMetricNameList.length) {
       console.error(
-        'Validation Error: metrics and output-metrics-names length must be equal.'
+        'Input Validation Error: metrics and output-metric-names length must be equal.'
+      );
+      return inputs;
+    }
+
+    if (hasDuplicates(outputMetricNameList)) {
+      console.error(
+        'Input Validation Error: output-metric-names contains duplicate values.'
       );
       return inputs;
     }
@@ -188,6 +195,10 @@ export const DatadogImporter = (
       }
     }
     return '';
+  }
+
+  function hasDuplicates(array: string[]) {
+    return new Set(array).size !== array.length;
   }
 
   return {


### PR DESCRIPTION

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [x] Enhancement (project structure, spelling, grammar, formatting)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.


### A description of the changes proposed in the Pull Request
This PR allows for any metric(s) to be retrieved instead of hardcoding cpu-utilization. It introduces two new globalConfigs in place of cpu-utilization-metric-name, which are metrics and output-metric-names. These two new inputs should be comma delimited if there are multiple metrics that we want to retrieve.


<!-- Make sure tests and lint pass on CI. -->

