### PR TITLE
5 group by tags

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,4 +10,4 @@ yarn-error.log
 build
 coverage
 .env
-test.y*ml
+test*.y*ml

--- a/.gitignore
+++ b/.gitignore
@@ -10,4 +10,6 @@ yarn-error.log
 build
 coverage
 .env
+.DS_Store
+**/.DS_Store
 test*.y*ml

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -1,0 +1,17 @@
+{
+  "version": "0.2.0",
+  "configurations": [
+      {
+          "type": "node",
+          "name": "vscode-jest-tests",
+          "request": "launch",
+          "console": "integratedTerminal",
+          "internalConsoleOptions": "neverOpen",
+          "program": "${workspaceFolder}/node_modules/.bin/jest",
+          "cwd": "${workspaceFolder}",
+          "args": [
+            "--verbose"
+          ]
+      }
+  ]
+}

--- a/src/__tests__/unit/lib/datadog-importer-plugin.test.ts
+++ b/src/__tests__/unit/lib/datadog-importer-plugin.test.ts
@@ -2,6 +2,10 @@ import {DatadogImporter} from '../../../lib';
 import {v1} from '@datadog/datadog-api-client';
 import {ApiException} from '@datadog/datadog-api-client/dist/packages/datadog-api-client-common';
 
+console.log = jest.fn();
+console.warn = jest.fn();
+console.error = jest.fn();
+
 jest.mock('@datadog/datadog-api-client', () => ({
   client: {
     createConfiguration: jest.fn(),
@@ -36,10 +40,10 @@ describe('DatadogImporter(): ', () => {
 
   const globalConfig = {
     'instance-id-tag': 'app',
-    'location-tag': 'region',
-    'instance-type-tag': 'instance-type',
     metrics: 'metric1,metric2',
     'output-metric-names': 'outputMetric1,outputMetric2',
+    tags: 'tag1,tag2',
+    'output-tag-names': 'outputTag1,outputTag2',
   };
 
   const validInput = [
@@ -51,6 +55,10 @@ describe('DatadogImporter(): ', () => {
   ];
 
   describe('execute(): ', () => {
+    beforeEach(() => {
+      jest.clearAllMocks();
+    });
+
     it('has metadata field.', () => {
       const pluginInstance = DatadogImporter({});
 
@@ -60,7 +68,7 @@ describe('DatadogImporter(): ', () => {
       expect(typeof pluginInstance.execute).toBe('function');
     });
 
-    it('should return the input if output-metric-names contains duplicate values', async () => {
+    it('should log error and return the input if output-metric-names contains duplicate values', async () => {
       const invalidConfig = {
         ...globalConfig,
         'output-metric-names': 'outputMetric1,outputMetric1',
@@ -68,9 +76,12 @@ describe('DatadogImporter(): ', () => {
       const importer = DatadogImporter(invalidConfig);
       const result = await importer.execute(validInput);
       expect(result).toEqual(validInput);
+      expect(console.error).toHaveBeenCalledWith(
+        'Input Validation Error: output-metric-names contains duplicate values.'
+      );
     });
 
-    it('should return the input if metrics and output-metric-names length are not equal', async () => {
+    it('should log error and return the input if metrics and output-metric-names length are not equal', async () => {
       const invalidConfig = {
         ...globalConfig,
         'output-metric-names': 'outputMetric1',
@@ -78,9 +89,12 @@ describe('DatadogImporter(): ', () => {
       const importer = DatadogImporter(invalidConfig);
       const result = await importer.execute(validInput);
       expect(result).toEqual(validInput);
+      expect(console.error).toHaveBeenCalledWith(
+        'Input Validation Error: metrics and output-metric-names length must be equal.'
+      );
     });
 
-    it('should return the input if a metric does not exist', async () => {
+    it('should log error and return the input if a metric does not exist', async () => {
       const createMockApiInstance = () => ({
         getMetricMetadata: jest
           .fn()
@@ -93,6 +107,37 @@ describe('DatadogImporter(): ', () => {
       const importer = DatadogImporter(globalConfig);
       const result = await importer.execute(validInput);
       expect(result).toEqual(validInput);
+      expect(console.error).toHaveBeenCalledWith(
+        'Metric metric1 does not exist'
+      );
+    });
+
+    it('should log error and return the input if output-tag-names contains duplicate values', async () => {
+      const invalidConfig = {
+        ...globalConfig,
+        'output-tag-names': 'outputTag1,outputTag1',
+      };
+
+      const importer = DatadogImporter(invalidConfig);
+      const result = await importer.execute(validInput);
+      expect(result).toEqual(validInput);
+      expect(console.error).toHaveBeenCalledWith(
+        'Input Validation Error: output-tag-names contains duplicate values.'
+      );
+    });
+
+    it('should log error and return the input if tags and output-tag-names length are not equal', async () => {
+      const invalidConfig = {
+        ...globalConfig,
+        'output-tag-names': 'outputTag1',
+      };
+
+      const importer = DatadogImporter(invalidConfig);
+      const result = await importer.execute(validInput);
+      expect(result).toEqual(validInput);
+      expect(console.error).toHaveBeenCalledWith(
+        'Input Validation Error: tags and output-tag-names length must be equal.'
+      );
     });
 
     it('should execute and return transformed data', async () => {
@@ -100,11 +145,7 @@ describe('DatadogImporter(): ', () => {
 
       const seriesDataMetric1 = [
         {
-          tagSet: [
-            'instance-id:i-123456',
-            'region:us-central',
-            'instance-type:t2.micro',
-          ],
+          tagSet: ['instance-id:i-123456', 'tag1:tag1value', 'tag2:tag2value'],
           pointlist: [
             [1717995600000, 1],
             [1717995610000, 0.7],
@@ -114,11 +155,7 @@ describe('DatadogImporter(): ', () => {
 
       const seriesDataMetric2 = [
         {
-          tagSet: [
-            'instance-id:i-123456',
-            'region:us-central',
-            'instance-type:t2.micro',
-          ],
+          tagSet: ['instance-id:i-123456', 'tag1:tag1value', 'tag2:tag2value'],
           pointlist: [
             [1717995600000, 0.25],
             [1717995610000, 0.14],
@@ -140,8 +177,8 @@ describe('DatadogImporter(): ', () => {
           'instance-id': 'i-123456',
           timestamp: '2024-06-10T05:00:00.000Z',
           duration: 10,
-          location: 'us-central',
-          'cloud/instance-type': 't2.micro',
+          outputTag1: 'tag1value',
+          outputTag2: 'tag2value',
           outputMetric1: 1,
           outputMetric2: 0.25,
         },
@@ -149,8 +186,8 @@ describe('DatadogImporter(): ', () => {
           'instance-id': 'i-123456',
           timestamp: '2024-06-10T05:00:10.000Z',
           duration: 10,
-          location: 'us-central',
-          'cloud/instance-type': 't2.micro',
+          outputTag1: 'tag1value',
+          outputTag2: 'tag2value',
           outputMetric1: 0.7,
           outputMetric2: 0.14,
         },


### PR DESCRIPTION
### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [ ] Enhancement (project structure, spelling, grammar, formatting)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.


### A description of the changes proposed in the Pull Request
<!--- Provide a small description of the changes. -->
- when the tag keys in the group by query have multiple combinations of values, datadog api returns a series with multiple entries, one per combination of group by tag values. This MR appends output for each of those combinations (before we were just doing the first one). This can be used in conjunction with the [group-by builtin](https://github.com/Green-Software-Foundation/if/tree/main/src/if-run/builtins#using-group-by) to dynamically generate a tree in the output
- allow the user to specify arbitrary group by tags, instead of just using location and instance-type
- add debug configuration for vscode


<!-- Make sure tests and lint pass on CI. -->

